### PR TITLE
feat(zendesk-app): add support for Gobocom subdomain API endpoint

### DIFF
--- a/zendesk_app/manifest.json
+++ b/zendesk_app/manifest.json
@@ -7,7 +7,8 @@
   },
   "defaultLocale": "en",
   "domainWhitelist": [
-    "api.quivr.app"
+    "api.quivr.app",
+    "api-gobocom.quivr.app"
   ],
   "private": false,
   "location": {
@@ -38,6 +39,6 @@
       "secure": true
     }
   ],
-  "version": "1.0.4",
+  "version": "1.0.5",
   "frameworkVersion": "2.0"
 }

--- a/zendesk_app/src/app/services/quivr.ts
+++ b/zendesk_app/src/app/services/quivr.ts
@@ -12,6 +12,12 @@ export class QuivrService {
   }
 
   private async initialize(client: any) {
+    this.apiUrl = await client.context().then(function (context) {
+      if (context.account.subdomain === 'locservice') {
+        return 'https://api-gobocom.quivr.app'
+      }
+      return 'https://api.quivr.app'
+    })
     this.quivrApiKey = await client.metadata().then(function (metadata) {
       return metadata.settings.quivr_api_token
     })

--- a/zendesk_app/src/manifest.json
+++ b/zendesk_app/src/manifest.json
@@ -7,7 +7,8 @@
   },
   "defaultLocale": "en",
   "domainWhitelist": [
-    "api.quivr.app"
+    "api.quivr.app",
+    "api-gobocom.quivr.app"
   ],
   "private": false,
   "location": {
@@ -38,6 +39,6 @@
       "secure": true
     }
   ],
-  "version": "1.0.4",
+  "version": "1.0.5",
   "frameworkVersion": "2.0"
 }


### PR DESCRIPTION
- Update manifest.json to whitelist api-gobocom.quivr.app domain
- Modify QuivrService to dynamically set API URL based on Zendesk account subdomain
- Bump version to 1.0.5