### PR TITLE
feat(frontend): add 'Translate Reply' option to ReplyBox and RightPanel components

### DIFF
--- a/zendesk_app/src/app/components/ReplyBoxApp/ReplyBoxApp.tsx
+++ b/zendesk_app/src/app/components/ReplyBoxApp/ReplyBoxApp.tsx
@@ -47,6 +47,14 @@ export const ReplyBoxApp = (): JSX.Element => {
       disabled: loading
     },
     {
+      label: 'Translate Reply',
+      onClick: () => {
+        submit('translate')
+      },
+      iconName: 'chevronRight',
+      disabled: loading
+    },
+    {
       label: 'Summarize Ticket',
       onClick: () => {
         submit('summarize')

--- a/zendesk_app/src/app/components/RightPanelApp/RightPanelApp.tsx
+++ b/zendesk_app/src/app/components/RightPanelApp/RightPanelApp.tsx
@@ -52,6 +52,14 @@ export const RightPanelApp = (): JSX.Element => {
       disabled: loading
     },
     {
+      label: 'Translate Reply',
+      onClick: () => {
+        submit('translate')
+      },
+      iconName: 'chevronRight',
+      disabled: loading
+    },
+    {
       label: 'Summarize Ticket',
       onClick: () => {
         submit('summarize')

--- a/zendesk_app/src/app/services/quivr.ts
+++ b/zendesk_app/src/app/services/quivr.ts
@@ -54,12 +54,12 @@ export class QuivrService {
           Authorization: `Bearer ${this.quivrApiKey}`,
           'Content-Type': 'application/json'
         },
-        secure: true,
+        secure: false,
         accepts: 'application/json',
         data: JSON.stringify({
           subdomain: `${subdomain}.zendesk.com`,
           email: userEmail,
-          api_key: '{{setting.zendesk_api_key}}',
+          api_key: 'your-api-key-here',
           time_range: 30
         })
       })

--- a/zendesk_app/src/app/services/quivr.ts
+++ b/zendesk_app/src/app/services/quivr.ts
@@ -54,12 +54,12 @@ export class QuivrService {
           Authorization: `Bearer ${this.quivrApiKey}`,
           'Content-Type': 'application/json'
         },
-        secure: false,
+        secure: true,
         accepts: 'application/json',
         data: JSON.stringify({
           subdomain: `${subdomain}.zendesk.com`,
           email: userEmail,
-          api_key: 'your-api-key-here',
+          api_key: '{{setting.zendesk_api_key}}',
           time_range: 30
         })
       })

--- a/zendesk_app/src/app/types/zendesk.d.ts
+++ b/zendesk_app/src/app/types/zendesk.d.ts
@@ -1,4 +1,4 @@
-export type ZendeskTask = 'iterate' | 'reformulate' | 'generate' | 'correct' | 'summarize'
+export type ZendeskTask = 'iterate' | 'reformulate' | 'generate' | 'correct' | 'summarize' | 'translate'
 
 export interface TicketIngestionProgress {
   total_tickets: number


### PR DESCRIPTION
- Introduced a new button for translating replies in both ReplyBoxApp and RightPanelApp.
- Updated the ZendeskTask type definition to include 'translate'.


<img width="1042" alt="image" src="https://github.com/user-attachments/assets/d715dfc0-5b1d-4490-8397-84e8deb5cea1" />
<img width="462" alt="image" src="https://github.com/user-attachments/assets/903c7cf8-8c51-4d20-9465-8668bbbf7ff1" />



