### PR TITLE
feat: add a feature flag to disable autosend feedback

### DIFF
--- a/zendesk_app/src/app/components/RightPanelApp/components/ResponseContainer/ResponseContainer.tsx
+++ b/zendesk_app/src/app/components/RightPanelApp/components/ResponseContainer/ResponseContainer.tsx
@@ -46,6 +46,9 @@ export const ResponseContainer = ({
   const [feedbackModalViewed, setFeedbackModalViewed] = useState(false)
   const openModal = useModal(client)
   const autosendFeedbackModalEnabled = useFeatureFlagEnabled(featureFlags.AUTOSEND_FEEDBACK_MODAL)
+  const autosendFeedbackEnabled = useFeatureFlagEnabled(featureFlags.AUTOSEND_FEEDBACK)
+  const showAutosendFeedbackButtons =
+    autoDraft?.prediction?.is_autosendable && autoDraft?.prediction?.is_accepted === null && autosendFeedbackEnabled
 
   useEffect(() => {
     if (!manualEditing) {
@@ -76,7 +79,8 @@ export const ResponseContainer = ({
         htmlContent !== '' &&
         subdomainsEligibleToAutosend.includes(subdomain) &&
         !feedbackModalViewed &&
-        autosendFeedbackModalEnabled
+        autosendFeedbackModalEnabled &&
+        autosendFeedbackEnabled
       ) {
         setFeedbackModalViewed(true)
         launchModalFeedback({ autosendable: true, askForFeedback: true })
@@ -178,7 +182,7 @@ export const ResponseContainer = ({
   return (
     <div className={styles.main_container}>
       <div
-        className={`${styles.response_container} ${autoDraft?.prediction?.is_autosendable ? styles.autosendable : ''}`}
+        className={`${styles.response_container} ${showAutosendFeedbackButtons ? styles.autosendable : ''}`}
         contentEditable={true}
         dangerouslySetInnerHTML={{ __html: htmlContent }}
         onInput={handleInput}
@@ -192,9 +196,7 @@ export const ResponseContainer = ({
       ></div>
       {!ongoingTask && (
         <>
-          {autoDraft?.prediction?.is_autosendable &&
-          autoDraft?.prediction?.is_accepted === null &&
-          isAutosendableFeedbackOpen ? (
+          {showAutosendFeedbackButtons && isAutosendableFeedbackOpen ? (
             <div className={styles.feedback_wrapper}>
               <div className={styles.autosend_container}>
                 <Tooltip

--- a/zendesk_app/src/app/constants/feature-flags.ts
+++ b/zendesk_app/src/app/constants/feature-flags.ts
@@ -1,3 +1,4 @@
 export const featureFlags = {
-  AUTOSEND_FEEDBACK_MODAL: 'autosend-feedback-modal'
+  AUTOSEND_FEEDBACK_MODAL: 'autosend-feedback-modal',
+  AUTOSEND_FEEDBACK: 'autosend-feedback'
 }


### PR DESCRIPTION
Closes ENT-1322

Add a feature flag to disable the automatic sending of feedback (not just the modal).
Currently, when we need to do this (e.g., for Locservice), we’re forced to disable the autosend prediction entirely.